### PR TITLE
establish a minimum improv environment

### DIFF
--- a/env/improv.yml
+++ b/env/improv.yml
@@ -1,0 +1,12 @@
+name: improv
+channels:
+- conda-forge
+dependencies:
+- numpy
+- scipy
+- matplotlib
+- pip
+- pyarrow
+- pyqt
+- python-lmdb
+- pyyaml

--- a/pytest/sample_demo.py
+++ b/pytest/sample_demo.py
@@ -1,10 +1,13 @@
-from improv.nexus import Nexus
 
 import logging
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
-loadFile = "./configs/sample_config.yaml"
 
-nexus = Nexus("Sample")
-nexus.createNexus(file=loadFile)
-nexus.startNexus()
+if __name__ == '__main__':
+    from improv.nexus import Nexus
+
+    loadFile = "./configs/sample_config.yaml"
+
+    nexus = Nexus("Sample")
+    nexus.createNexus(file=loadFile)
+    nexus.startNexus()

--- a/pytest/sample_demo.py
+++ b/pytest/sample_demo.py
@@ -1,10 +1,10 @@
+from improv.nexus import Nexus
 
 import logging
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
 
 if __name__ == '__main__':
-    from improv.nexus import Nexus
 
     loadFile = "./configs/sample_config.yaml"
 


### PR DESCRIPTION
Added a minimal env file to list dependencies needed for only the most basic improv programs. 

Updated `/pytest/sample_demo.py` to use best-practice command line 
```python
if __name__ == '__main__':
```