### PR TITLE
better actor traceback

### DIFF
--- a/improv/actor.py
+++ b/improv/actor.py
@@ -239,13 +239,13 @@ class RunManager():
                     self.actions['run']()
                 except Exception as e:
                     logger.error('Actor '+self.actorName+' exception during run: {}'.format(e))
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
             elif self.stop:
                 try:
                     self.actions['stop']()
                 except Exception as e:
                     logger.error('Actor '+self.actorName+' exception during stop: {}'.format(e))
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
                 self.stop = False #Run once
             elif self.config:
                 try:
@@ -255,7 +255,7 @@ class RunManager():
                     self.q_comm.put([Signal.ready()])
                 except Exception as e:
                     logger.error('Actor '+self.actorName+' exception during setup: {}'.format(e))  
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
                 self.config = False 
 
             # Check for new Signals received from Nexus


### PR DESCRIPTION
ran into this while troubleshooting, not sure if it's best to display them in the textual message area too? I'm guessing the prints no longer appear when you merged the TUI

example before:
```python
improv.actor Actor ScanImageReceiver exception during run: 'int' object has no attribute 'tobytes'
```

this PR:
```python
improv.actor Actor ScanImageReceiver exception during run: 'int' object has no attribute 'tobytes'
improv.actor Traceback (most recent call last):
  File "/home/kushalk/repos/improv/improv/actor.py", line 239, in __enter__
    self.actions['run']()
  File "/home/kushalk/repos/serenity/serenity/actors/datamanager.py", line 131, in runStep
    self.q_out.put(frame.to_bytes())
  File "/home/kushalk/repos/serenity/serenity/io/_frame.py", line 170, in to_bytes
    b.extend(getattr(self, [he.name](http://he.name/)).tobytes())
AttributeError: 'int' object has no attribute 'tobytes'
```