### PR TITLE
Exclude demos and build from Black format check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,12 @@ per-file-ignores = """
     test/test_link.py:PT012
     """
 exclude = ["demos", "build"]
+
+[tool.black]
+line-length = 88
+exclude = '''
+/(
+    demos
+  | build
+)/
+'''


### PR DESCRIPTION
Add Black config to pyproject.toml so that it will exclude demos and build from formatting check.