### PR TITLE
Server config

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -3,11 +3,11 @@ name: Python testing
 on:
   pull_request: 
     branches:
-      - master
+      - main
       - dev
   push:
     branches:
-      - master
+      - main
       - dev
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: build docs
 
 on:
   # Trigger the workflow on push to main branch
@@ -13,18 +13,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v2
 
     # Install dependencies
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install -r docs/requirements.txt
+        pip install -e .[docs]
 
     # Build the book
     - name: Build the book

--- a/.gitignore
+++ b/.gitignore
@@ -112,8 +112,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
+# documentation
 /site
+docs/_autosummary
 
 # mypy
 .mypy_cache/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,3 +35,14 @@ repository:
 html:
   use_issues_button: true
   use_repository_button: true
+
+sphinx:
+  extra_extensions:
+  - 'autoapi.extension'
+  - 'sphinx.ext.napoleon'
+  - 'sphinx.ext.viewcode'
+  config:
+    autoapi_dirs: '../improv'
+    autoapi_options: ['members', 'undoc-members', 'show-inheritance', 'show-module-summary', 'imported-members', ] 
+
+only_build_toc_files: true

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -7,3 +7,5 @@ chapters:
 - file: markdown
 - file: notebooks
 - file: markdown-notebooks
+- file: content
+- file: autoapi/index

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-jupyter-book
-matplotlib
-numpy

--- a/improv/actor.py
+++ b/improv/actor.py
@@ -46,7 +46,9 @@ class AbstractActor:
 
     def setStoreInterface(self, client):
         """Sets the client interface to the store
-        Used specifically for actors not inheriting Nexus' memory
+
+        Args:
+            client (improv.store.StoreInterface): Set client interface to the store
         """
         self.client = client
 
@@ -57,34 +59,48 @@ class AbstractActor:
             self.setStoreInterface(store)
 
     def setLinks(self, links):
-        """General full dict set for links"""
-        self.links = links
+        """General full dict set for links
 
-    def getLinks(self):
-        """Returns dictionary of links"""
-        return self.links
+        Args:
+            links (dict): The dict to store all the links
+        """
+        self.links = links
 
     def setCommLinks(self, q_comm, q_sig):
         """Set explicit communication links to/from Nexus (q_comm, q_sig)
-        q_comm is for messages from this actor to Nexus
-        q_sig is signals from Nexus and must be checked first
+
+        Args:
+            q_comm (improv.nexus.Link): for messages from this actor to Nexus
+            q_sig (improv.nexus.Link): signals from Nexus and must be checked first
         """
         self.q_comm = q_comm
         self.q_sig = q_sig
         self.links.update({"q_comm": self.q_comm, "q_sig": self.q_sig})
 
     def setLinkIn(self, q_in):
-        """Set the dedicated input queue"""
+        """Set the dedicated input queue
+
+        Args:
+            q_in (improv.nexus.Link): for input signals to this actor
+        """
         self.q_in = q_in
         self.links.update({"q_in": self.q_in})
 
     def setLinkOut(self, q_out):
-        """Set the dedicated output queue"""
+        """Set the dedicated output queue
+
+        Args:
+            q_out (improv.nexus.Link): for output signals from this actor
+        """
         self.q_out = q_out
         self.links.update({"q_out": self.q_out})
 
     def setLinkWatch(self, q_watch):
-        """Set the queue for the Watcher, if used"""
+        """Set the dedicated watchout queue
+
+        Args:
+            q_watch (improv.nexus.Link): watchout queue
+        """
         self.q_watchout = q_watch
         self.links.update({"q_watchout": self.q_watchout})
 
@@ -92,10 +108,22 @@ class AbstractActor:
         """Function provided to add additional data links by name
         using same form as q_in or q_out
         Must be done during registration and not during run
+
+        Args:
+            name (string): customized link name
+            link (improv.nexus.Link): customized data link
         """
         self.links.update({name: link})
         # User can then use: self.my_queue = self.links['my_queue'] in a setup fcn,
         # or continue to reference it using self.links['my_queue']
+
+    def getLinks(self):
+        """Returns dictionary of links for the current actor
+
+        Returns:
+            dict: dictionary of links
+        """
+        return self.links
 
     def put(self, idnames, q_out=None, save=None):
         """TODO: This is deprecated? Prefer using Links explicitly"""
@@ -288,7 +316,8 @@ class RunManager:
 
 
 class AsyncRunManager:
-    """Asynchronous run manager. Communicates with nexus core using q_sig and q_comm.
+    """
+    Asynchronous run manager. Communicates with nexus core using q_sig and q_comm.
     To be used with [async with]
     Afterwards, the run manager listens for signals without blocking.
     """

--- a/improv/config.py
+++ b/improv/config.py
@@ -29,7 +29,7 @@ class Config:
                 self.settings = {}
             
             if not "use_watcher" in self.settings:
-                self.settings["use_watcher"] = None
+                self.settings["use_watcher"] = False
 
         except TypeError:
             if cfg is None:

--- a/improv/config.py
+++ b/improv/config.py
@@ -134,7 +134,15 @@ class ConfigModule:
         self.options = options
 
     def saveConfigModules(self, pathName, wflag):
-        """Loops through each actor to save the modules to the config file."""
+        """Loops through each actor to save the modules to the config file.
+
+        Args:
+            pathName:
+            wflag (bool):
+
+        Returns:
+            bool: wflag
+        """
 
         if wflag:
             writeOption = "w"

--- a/improv/config.py
+++ b/improv/config.py
@@ -27,8 +27,8 @@ class Config:
                 self.settings = cfg["settings"]
             else:
                 self.settings = {}
-            
-            if not "use_watcher" in self.settings:
+
+            if "use_watcher" not in self.settings:
                 self.settings["use_watcher"] = False
 
         except TypeError:
@@ -38,7 +38,7 @@ class Config:
         if type(cfg) is not dict:
             logger.error("Error: The config file is not in dictionary format")
             raise TypeError
-        
+
         self.config = cfg
 
         self.actors = {}

--- a/improv/config.py
+++ b/improv/config.py
@@ -19,6 +19,28 @@ class Config:
             # Reading config from other yaml file
             self.configFile = configFile
 
+        with open(self.configFile, "r") as ymlfile:
+            cfg = yaml.safe_load(ymlfile)
+
+        try:
+            if "settings" in cfg:
+                self.settings = cfg["settings"]
+            else:
+                self.settings = {}
+            
+            if not "use_watcher" in self.settings:
+                self.settings["use_watcher"] = None
+
+        except TypeError:
+            if cfg is None:
+                logger.error("Error: The config file is empty")
+
+        if type(cfg) is not dict:
+            logger.error("Error: The config file is not in dictionary format")
+            raise TypeError
+        
+        self.config = cfg
+
         self.actors = {}
         self.connections = {}
         self.hasGUI = False
@@ -28,22 +50,7 @@ class Config:
         TODO: check for config file compliance, error handle it
         beyond what we have below.
         """
-        with open(self.configFile, "r") as ymlfile:
-            cfg = yaml.safe_load(ymlfile)
-
-        try:
-            if "settings" in cfg:
-                self.settings = cfg["settings"]
-            else:
-                self.settings = {}
-                self.settings["use_watcher"] = None
-        except TypeError:
-            if cfg is None:
-                logger.error("Error: The config file is empty")
-
-        if type(cfg) is not dict:
-            logger.error("Error: The config file is not in dictionary format")
-            raise TypeError
+        cfg = self.config
 
         for name, actor in cfg["actors"].items():
             if name in self.actors.keys():

--- a/improv/link.py
+++ b/improv/link.py
@@ -180,12 +180,17 @@ class AsyncQueue(object):
         the status to pending. Once the get has returned, it returns the
         result of the get and sets its status as done.
 
+        Explicitly passes any exceptions to not hinder execution.
+        Errors are logged with the get_async tag.
+
         Returns:
             Awaitable or result of the get.
 
-        Exceptions:
-            Explicitly passes any exceptions to not hinder execution.
-            Errors are logged with the get_async tag.
+        Raises:
+            CancelledError: task is cancelled
+            EOFError:
+            FileNotFoundError:
+            Exception:
         """
         loop = asyncio.get_event_loop()
         self.status = "pending"

--- a/improv/nexus.py
+++ b/improv/nexus.py
@@ -43,8 +43,22 @@ class Nexus:
         control_port=0,
         output_port=0,
     ):
-        """Start the server, the store, and load the config file.
-        This will also create the actors.
+        """Function to initialize class variables based on config file.
+
+        Starts a store of class Limbo, and then loads the config file.
+        The config file specifies the specific actors that nexus will
+        be connected to, as well as their links.
+
+        Args:
+            file (string): Name of the config file.
+            use_hdd (bool): Whether to use hdd for the store.
+            use_watcher (bool): Whether to use watcher for the store.
+            store_size (int): initial store size
+            control_port (int): port number for input socket
+            output_port (int): port number for output socket
+
+        Returns:
+            string: "Shutting down", to notify start() that pollQueues has completed.
         """
 
         curr_dt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -132,12 +146,16 @@ class Nexus:
         create a Link with a name (purpose), start, and end
         Start links to one actor's name, end to the other.
         Nexus gives start_actor the Link as a q_in,
-          and end_actor the Link as a q_out
+        and end_actor the Link as a q_out.
         Nexus maintains dict of name and associated Link.
         Nexus also has list of Links that it is itself connected to
-          for communication purposes.
+        for communication purposes.
+
         OR
         For each connection, create 2 Links. Nexus acts as intermediary.
+
+        Args:
+            file (string): input config filepath
         """
         # TODO load from file or user input, as in dialogue through FrontEnd?
 
@@ -212,7 +230,7 @@ class Nexus:
     def startNexus(self):
         """
         Puts all actors in separate processes and begins polling
-            to listen to comm queues
+        to listen to comm queues
         """
         for name, m in self.actors.items():
             if "GUI" not in name:  # GUI already started
@@ -254,6 +272,9 @@ class Nexus:
         self.zmq_context.destroy()
 
     def start(self):
+        """
+        Start all the processes in Nexus
+        """
         logger.info("Starting processes")
 
         for p in self.processes:
@@ -289,7 +310,7 @@ class Nexus:
         stopped.
 
         Returns:
-            "Shutting down" (string): Notifies start() that pollQueues has completed.
+            string: "Shutting down", Notifies start() that pollQueues has completed.
         """
         self.actorStates = dict.fromkeys(self.actors.keys())
         if not self.config.hasGUI:
@@ -347,9 +368,19 @@ class Nexus:
         return "Shutting Down"
 
     def stop_polling_and_quit(self, signal, queues):
-        logger.warn("Shutting down via signal handler for {}".format(signal))
-        logger.warn("Steps may be out of order or dirty.")
+        """
+        quit the process and stop polling signals from queues
 
+        Args:
+            signal (): Signal for signal handler.
+            queues (improv.link.AsyncQueue): Comm queues for links.
+        """
+        logger.warn(
+            "Shutting down via signal handler for {}. \
+                Steps may be out of order or dirty.".format(
+                signal
+            )
+        )
         self.stop_polling(signal, queues)
         self.flags["quit"] = True
         self.early_exit = True
@@ -521,8 +552,8 @@ class Nexus:
         the next run of the event loop.
 
         Args:
-            stop_signal (signal.signal): Signal for signal handler.
-            queues (AsyncQueue): Comm queues for links.
+            stop_signal (): Signal for signal handler.
+            queues (improv.link.AsyncQueue): Comm queues for links.
         """
         logger.info("Received shutdown order")
 
@@ -558,6 +589,14 @@ class Nexus:
         Raises an Exception if the plasma store doesn't start
 
         #TODO: Generalize this to non-plasma stores
+
+        Args:
+            size: in bytes
+
+        Raises:
+            RuntimeError: if the size is undefined
+            Exception: if the plasma store doesn't start
+
         """
         if size is None:
             raise RuntimeError("Server size needs to be specified")
@@ -594,6 +633,10 @@ class Nexus:
     def createActor(self, name, actor):
         """Function to instantiate actor, add signal and comm Links,
         and update self.actors dictionary
+
+        Args:
+            name: name of the actor
+            actor: improv.actor.Actor
         """
         # Instantiate selected class
         mod = import_module(actor.packagename)
@@ -626,6 +669,9 @@ class Nexus:
     def runActor(self, actor):
         """Run the actor continually; used for separate processes
         #TODO: hook into monitoring here?
+
+        Args:
+            actor:
         """
         actor.run()
 
@@ -654,6 +700,8 @@ class Nexus:
         Actor must already be instantiated
 
         #NOTE: Could use this for reassigning links if actors crash?
+
+        #TODO: Adjust to use default q_out and q_in vs being specified
         """
         classname = name.split(".")[0]
         linktype = name.split(".")[1]

--- a/improv/nexus.py
+++ b/improv/nexus.py
@@ -38,7 +38,7 @@ class Nexus:
         self,
         file=None,
         use_hdd=False,
-        use_watcher=False,
+        use_watcher=None,
         store_size=10_000_000,
         control_port=0,
         output_port=0,
@@ -60,19 +60,18 @@ class Nexus:
                 logger.info(f.read())
         
         # set config options loaded from file
-        # in Python 3.9, can just merge dictionaries
+        # in Python 3.9, can just merge dictionaries using precedence
         cfg = self.config.settings
         if 'use_hdd' not in cfg:
-            cfg['use_hdd'] = use_hdd
-        if 'use_watcher' not in cfg:
-            cfg['use_watcher'] = use_wather
+            cfg["use_hdd"] = use_hdd
+        if "use_watcher" not in cfg:
+            cfg['use_watcher'] = use_watcher
         if 'store_size' not in cfg:
             cfg['store_size'] = store_size 
-        if control_port != 0:
+        if 'control_port' not in cfg or control_port != 0:
             cfg['control_port'] = control_port
-        if output_port != 0:
+        if 'output_port' not in cfg or output_port != 0:
             cfg['output_port'] = output_port
-        
 
         # set up socket in lieu of printing to stdout
         self.zmq_context = zmq.Context()
@@ -96,14 +95,14 @@ class Nexus:
         self.store.subscribe()
 
         # LMDB storage
-        self.use_hdd = use_hdd
+        self.use_hdd = cfg["use_hdd"]
         if self.use_hdd:
             self.lmdb_name = f'lmdb_{datetime.now().strftime("%Y%m%d_%H%M%S")}'
             self.store_dict = dict()
 
         # TODO: Better logic/flow for using watcher as an option
         self.p_watch = None
-        if use_watcher:
+        if cfg['use_watcher']:
             self.startWatcher()
 
         # Create dicts for reading config and creating actors
@@ -202,7 +201,7 @@ class Nexus:
         for name, link in self.data_queues.items():
             self.assignLink(name, link)
 
-        if self.config.settings["use_watcher"] is not None:
+        if self.config.settings["use_watcher"]:
             watchin = []
             for name in self.config.settings["use_watcher"]:
                 watch_link = Link(name + "_watch", name, "Watcher")

--- a/improv/nexus.py
+++ b/improv/nexus.py
@@ -133,7 +133,7 @@ class Nexus:
         self.allowStart = False
         self.stopped = False
 
-        return (control_port, output_port)
+        return (cfg["control_port"], cfg["output_port"])
 
     def loadConfig(self, file):
         """Load configuration file.

--- a/improv/nexus.py
+++ b/improv/nexus.py
@@ -39,7 +39,7 @@ class Nexus:
         file=None,
         use_hdd=False,
         use_watcher=False,
-        store_size=10000000,
+        store_size=10_000_000,
         control_port=0,
         output_port=0,
     ):
@@ -50,19 +50,43 @@ class Nexus:
         curr_dt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         logger.info(f"************ new improv server session {curr_dt} ************")
 
+        if file is None:
+            logger.exception("Need a config file!")
+            raise Exception  # TODO
+        else:
+            logger.info(f"Loading configuration file {file}:")
+            self.loadConfig(file=file)
+            with open(file, 'r') as f:  #write config file to log
+                logger.info(f.read())
+        
+        # set config options loaded from file
+        # in Python 3.9, can just merge dictionaries
+        cfg = self.config.settings
+        if 'use_hdd' not in cfg:
+            cfg['use_hdd'] = use_hdd
+        if 'use_watcher' not in cfg:
+            cfg['use_watcher'] = use_wather
+        if 'store_size' not in cfg:
+            cfg['store_size'] = store_size 
+        if control_port != 0:
+            cfg['control_port'] = control_port
+        if output_port != 0:
+            cfg['output_port'] = output_port
+        
+
         # set up socket in lieu of printing to stdout
         self.zmq_context = zmq.Context()
         self.out_socket = self.zmq_context.socket(PUB)
-        self.out_socket.bind("tcp://*:%s" % output_port)
+        self.out_socket.bind("tcp://*:%s" % cfg['output_port'])
         out_port_string = self.out_socket.getsockopt_string(SocketOption.LAST_ENDPOINT)
-        output_port = int(out_port_string.split(":")[-1])
+        cfg['output_port'] = int(out_port_string.split(":")[-1])
 
         self.in_socket = self.zmq_context.socket(REP)
-        self.in_socket.bind("tcp://*:%s" % control_port)
+        self.in_socket.bind("tcp://*:%s" % cfg['control_port'])
         in_port_string = self.in_socket.getsockopt_string(SocketOption.LAST_ENDPOINT)
-        control_port = int(in_port_string.split(":")[-1])
+        cfg['control_port'] = int(in_port_string.split(":")[-1])
 
-        # default size should be system-dependent; this is 40 GB
+        # default size should be system-dependent
         self._startStoreInterface(store_size)
         self.out_socket.send_string("StoreInterface started")
 
@@ -90,19 +114,21 @@ class Nexus:
         self.flags = {}
         self.processes = []
 
-        if file is None:
-            logger.exception("Need a config file!")
-            raise Exception  # TODO
-        else:
-            self.loadConfig(file=file)
+        self.initConfig()
 
         self.flags.update({"quit": False, "run": False, "load": False})
         self.allowStart = False
         self.stopped = False
 
         return (control_port, output_port)
-
+    
     def loadConfig(self, file):
+        """Load configuration file. 
+        file: a YAML configuration file name
+        """
+        self.config = Config(configFile=file)
+
+    def initConfig(self):
         """For each connection:
         create a Link with a name (purpose), start, and end
         Start links to one actor's name, end to the other.
@@ -116,7 +142,6 @@ class Nexus:
         """
         # TODO load from file or user input, as in dialogue through FrontEnd?
 
-        self.config = Config(configFile=file)
         flag = self.config.createConfig()
         if flag == -1:
             logger.error(
@@ -245,13 +270,14 @@ class Nexus:
         logger.warning("Destroying Nexus")
         self._closeStoreInterface()
 
-        try:
-            os.remove(self.store_loc)
-        except FileNotFoundError:
-            logger.warning(
-                "StoreInterface file {} is already deleted".format(self.store_loc)
-            )
-        logger.warning("Delete the store at location {0}".format(self.store_loc))
+        if hasattr(self, 'store_loc'):
+            try:
+                os.remove(self.store_loc)
+            except FileNotFoundError:
+                logger.warning(
+                    "StoreInterface file {} is already deleted".format(self.store_loc)
+                )
+            logger.warning("Delete the store at location {0}".format(self.store_loc))
 
     async def pollQueues(self):
         """

--- a/improv/nexus.py
+++ b/improv/nexus.py
@@ -56,34 +56,34 @@ class Nexus:
         else:
             logger.info(f"Loading configuration file {file}:")
             self.loadConfig(file=file)
-            with open(file, 'r') as f:  #write config file to log
+            with open(file, "r") as f:  # write config file to log
                 logger.info(f.read())
-        
+
         # set config options loaded from file
         # in Python 3.9, can just merge dictionaries using precedence
         cfg = self.config.settings
-        if 'use_hdd' not in cfg:
+        if "use_hdd" not in cfg:
             cfg["use_hdd"] = use_hdd
         if "use_watcher" not in cfg:
-            cfg['use_watcher'] = use_watcher
-        if 'store_size' not in cfg:
-            cfg['store_size'] = store_size 
-        if 'control_port' not in cfg or control_port != 0:
-            cfg['control_port'] = control_port
-        if 'output_port' not in cfg or output_port != 0:
-            cfg['output_port'] = output_port
+            cfg["use_watcher"] = use_watcher
+        if "store_size" not in cfg:
+            cfg["store_size"] = store_size
+        if "control_port" not in cfg or control_port != 0:
+            cfg["control_port"] = control_port
+        if "output_port" not in cfg or output_port != 0:
+            cfg["output_port"] = output_port
 
         # set up socket in lieu of printing to stdout
         self.zmq_context = zmq.Context()
         self.out_socket = self.zmq_context.socket(PUB)
-        self.out_socket.bind("tcp://*:%s" % cfg['output_port'])
+        self.out_socket.bind("tcp://*:%s" % cfg["output_port"])
         out_port_string = self.out_socket.getsockopt_string(SocketOption.LAST_ENDPOINT)
-        cfg['output_port'] = int(out_port_string.split(":")[-1])
+        cfg["output_port"] = int(out_port_string.split(":")[-1])
 
         self.in_socket = self.zmq_context.socket(REP)
-        self.in_socket.bind("tcp://*:%s" % cfg['control_port'])
+        self.in_socket.bind("tcp://*:%s" % cfg["control_port"])
         in_port_string = self.in_socket.getsockopt_string(SocketOption.LAST_ENDPOINT)
-        cfg['control_port'] = int(in_port_string.split(":")[-1])
+        cfg["control_port"] = int(in_port_string.split(":")[-1])
 
         # default size should be system-dependent
         self._startStoreInterface(store_size)
@@ -102,7 +102,7 @@ class Nexus:
 
         # TODO: Better logic/flow for using watcher as an option
         self.p_watch = None
-        if cfg['use_watcher']:
+        if cfg["use_watcher"]:
             self.startWatcher()
 
         # Create dicts for reading config and creating actors
@@ -120,9 +120,9 @@ class Nexus:
         self.stopped = False
 
         return (control_port, output_port)
-    
+
     def loadConfig(self, file):
-        """Load configuration file. 
+        """Load configuration file.
         file: a YAML configuration file name
         """
         self.config = Config(configFile=file)
@@ -269,7 +269,7 @@ class Nexus:
         logger.warning("Destroying Nexus")
         self._closeStoreInterface()
 
-        if hasattr(self, 'store_loc'):
+        if hasattr(self, "store_loc"):
             try:
                 os.remove(self.store_loc)
             except FileNotFoundError:

--- a/improv/replayer.py
+++ b/improv/replayer.py
@@ -12,9 +12,10 @@ class Replayer(Actor):
         """
         Class that outputs objects to queues based on a saved previous run.
 
-        :param lmdb_path: path to LMDB folder
-        :param replay: named of Actor to replay.
-        :param resave: (if using LMDB in this instance)
+        Args:
+            lmdb_path: path to LMDB folder
+            replay: named of Actor to replay.
+            resave: (if using LMDB in this instance)
                         save outputs from this actor as usual (default: False)
 
         """
@@ -36,9 +37,13 @@ class Replayer(Actor):
         """
         Load saved queue objects from LMDB
 
-        :param replay: named of Actor
-        :param func: (optional) Function to apply to objects before returning
-        :return:
+        Args:
+            replay: named of Actor
+            func: (optional) Function to apply to objects before returning
+
+        Returns:
+            lmdb_values
+
         """
         # Get all out queue names
         replay = f"q__{replay}"
@@ -67,7 +72,11 @@ class Replayer(Actor):
         self.put_setup(self.lmdb_values)
 
     def move_to_plasma(self, lmdb_values):
-        """Put objects into current plasma store and update object ID in saved queue."""
+        """Put objects into current plasma store and update object ID in saved queue.
+
+        Args:
+            lmdb_values:
+        """
 
         # TODO Make async to enable queue-based fetch system -
         # to avoid loading everything at once.
@@ -98,7 +107,11 @@ class Replayer(Actor):
                 pass
 
     def put_setup(self, lmdb_values):
-        """Put all objects created before Run into queue immediately."""
+        """Put all objects created before Run into queue immediately.
+
+        Args:
+            lmdb_values:
+        """
         for lmdb_value in lmdb_values:
             if lmdb_value.time < self.t_saved_start_run:
                 getattr(self, lmdb_value.queue).put(lmdb_value.obj)

--- a/improv/utils/checks.py
+++ b/improv/utils/checks.py
@@ -27,11 +27,11 @@ def check_if_connections_acyclic(path_to_yaml):
     Print 'No loops.' if the connections are acyclic.
     Print 'Loop(s) found.' followed by the loop path if loops are found.
 
-    :param path_to_yaml: Path to the YAML file.
-    :type path_to_yaml: str
+    Args:
+        path_to_yaml (str): Path to the YAML file.
 
-    :return: Whether the connections are acyclic.
-    :rtype: bool
+    Returns:
+        bool: Whether the connections are acyclic.
 
     """
     with open(path_to_yaml) as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = ['Development Status :: 1 - Planning']
 
 [project.optional-dependencies]
 tests = ["pytest", "async-timeout", "pytest-asyncio", "pytest-cov", "scikit-image",]
-docs = ["jupyter-book"]
+docs = ["jupyter-book", "sphinx-autoapi"]
 lint = ["black", "flake8", "Flake8-pyproject", "flake8-pytest-style"]
 bw_demo = ["pyqtgraph", "mat73", "jax[cpu]", "proSVD",  
            "bubblewrap@git+https://github.com/pearsonlab/Bubblewrap",]

--- a/test/configs/minimal_with_settings.yaml
+++ b/test/configs/minimal_with_settings.yaml
@@ -4,6 +4,8 @@ settings:
   control_port: 6000
   output_port: 6001
   logging_port: 6002
+  use_hdd: false
+  use_watcher: false
 
 actors:
   Generator:

--- a/test/configs/minimal_with_settings.yaml
+++ b/test/configs/minimal_with_settings.yaml
@@ -1,0 +1,18 @@
+settings:
+  store_size: 20_000_000
+  not_relevant: for testing purposes
+  control_port: 6000
+  output_port: 6001
+  logging_port: 6002
+
+actors:
+  Generator:
+    package: actors.sample_generator
+    class: Generator
+
+  Processor:
+    package: actors.sample_processor
+    class: Processor
+
+connections:
+  Generator.q_out: [Processor.q_in]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,7 +6,7 @@ import yaml
 # from importlib import import_module
 
 # from improv.config import RepeatedActorError
-from improv.config import Config 
+from improv.config import Config
 from improv.utils import checks
 
 import logging
@@ -150,14 +150,14 @@ def test_createConfig_blank_file(set_configdir):
     """Tests if a blank config file raises an error."""
 
     with pytest.raises(TypeError):
-        cfg = Config("blank_file.yaml")
+        Config("blank_file.yaml")
 
 
 def test_createConfig_nonsense_file(set_configdir, caplog):
     """Tests if an improperly formatted config raises an error."""
 
     with pytest.raises(TypeError):
-        cfg = Config("nonsense.yaml")
+        Config("nonsense.yaml")
 
 
 def test_acyclic_graph(set_configdir):
@@ -185,8 +185,9 @@ def test_saveActors_clean(set_configdir):
 
     assert savedKeys == originalKeys
 
+
 def test_config_settings_read(set_configdir):
     cfg = Config("minimal_with_settings.yaml")
     cfg.createConfig()
 
-    assert 'store_size' in cfg.settings
+    assert "store_size" in cfg.settings

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -72,7 +72,7 @@ def test_createConfig_settings(set_configdir):
 
     cfg = Config("good_config.yaml")
     cfg.createConfig()
-    assert cfg.settings == {"use_watcher": None}
+    assert cfg.settings == {"use_watcher": False}
 
 
 # File with syntax error cannot pass the format check

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,7 +6,7 @@ import yaml
 # from importlib import import_module
 
 # from improv.config import RepeatedActorError
-from improv.config import Config as config
+from improv.config import Config 
 from improv.utils import checks
 
 import logging
@@ -33,7 +33,7 @@ def test_init(test_input, set_configdir):
         Whether config has the correct config file.
     """
 
-    cfg = config(test_input)
+    cfg = Config(test_input)
     assert cfg.configFile == test_input
 
 
@@ -70,7 +70,7 @@ def test_createConfig_settings(set_configdir):
         If the default setting is the dictionary {"use_watcher": "None"}
     """
 
-    cfg = config("good_config.yaml")
+    cfg = Config("good_config.yaml")
     cfg.createConfig()
     assert cfg.settings == {"use_watcher": None}
 
@@ -95,7 +95,7 @@ def test_createConfig_wrong_import(set_configdir):
         If createConfig raise any errors.
     """
 
-    cfg = config("minimal_wrong_import.yaml")
+    cfg = Config("minimal_wrong_import.yaml")
     res = cfg.createConfig()
     assert res == -1
 
@@ -107,7 +107,7 @@ def test_createConfig_clean(set_configdir):
         If createConfig does not raise any errors.
     """
 
-    cfg = config("good_config.yaml")
+    cfg = Config("good_config.yaml")
     try:
         cfg.createConfig()
     except Exception as exc:
@@ -117,7 +117,7 @@ def test_createConfig_clean(set_configdir):
 def test_createConfig_noActor(set_configdir):
     """Tests if AttributeError is raised when there are no actors."""
 
-    cfg = config("no_actor.yaml")
+    cfg = Config("no_actor.yaml")
     with pytest.raises(AttributeError):
         cfg.createConfig()
 
@@ -125,7 +125,7 @@ def test_createConfig_noActor(set_configdir):
 def test_createConfig_ModuleNotFound(set_configdir):
     """Tests if an error is raised when the package can"t be found."""
 
-    cfg = config("bad_package.yaml")
+    cfg = Config("bad_package.yaml")
     res = cfg.createConfig()
     assert res == -1
 
@@ -133,7 +133,7 @@ def test_createConfig_ModuleNotFound(set_configdir):
 def test_createConfig_class_ImportError(set_configdir):
     """Tests if an error is raised when the class name is invalid."""
 
-    cfg = config("bad_class.yaml")
+    cfg = Config("bad_class.yaml")
     res = cfg.createConfig()
     assert res == -1
 
@@ -141,7 +141,7 @@ def test_createConfig_class_ImportError(set_configdir):
 def test_createConfig_AttributeError(set_configdir):
     """Tests if AttributeError is raised."""
 
-    cfg = config("bad_class.yaml")
+    cfg = Config("bad_class.yaml")
     res = cfg.createConfig()
     assert res == -1
 
@@ -149,17 +149,15 @@ def test_createConfig_AttributeError(set_configdir):
 def test_createConfig_blank_file(set_configdir):
     """Tests if a blank config file raises an error."""
 
-    cfg = config("blank_file.yaml")
     with pytest.raises(TypeError):
-        cfg.createConfig()
+        cfg = Config("blank_file.yaml")
 
 
 def test_createConfig_nonsense_file(set_configdir, caplog):
     """Tests if an improperly formatted config raises an error."""
 
-    cfg = config("nonsense.yaml")
     with pytest.raises(TypeError):
-        cfg.createConfig()
+        cfg = Config("nonsense.yaml")
 
 
 def test_acyclic_graph(set_configdir):
@@ -175,7 +173,7 @@ def test_cyclic_graph(set_configdir):
 def test_saveActors_clean(set_configdir):
     """Compares internal actor representation to what was saved in the file."""
 
-    cfg = config("good_config.yaml")
+    cfg = Config("good_config.yaml")
     cfg.createConfig()
     cfg.saveActors()
 
@@ -186,3 +184,9 @@ def test_saveActors_clean(set_configdir):
     originalKeys = len(cfg.actors.keys())
 
     assert savedKeys == originalKeys
+
+def test_config_settings_read(set_configdir):
+    cfg = Config("minimal_with_settings.yaml")
+    cfg.createConfig()
+
+    assert 'store_size' in cfg.settings

--- a/test/test_nexus.py
+++ b/test/test_nexus.py
@@ -7,6 +7,7 @@ import signal
 
 from improv.nexus import Nexus
 from improv.store import StoreInterface
+from subprocess import TimeoutExpired
 
 
 # from improv.actor import Actor
@@ -97,6 +98,13 @@ def test_createNexus(setdir, ports):
     nex.destroyNexus()
     assert True
 
+def test_config_logged(setdir, ports, caplog):
+    nex = Nexus("test")
+    nex.createNexus(
+        file="minimal_with_settings.yaml", control_port=ports[0], output_port=ports[1]
+    )
+    nex.destroyNexus()
+    assert any(["not_relevant: for testing purposes" in record.msg for record in caplog.records])
 
 def test_loadConfig(sample_nex):
     nex = sample_nex
@@ -105,6 +113,18 @@ def test_loadConfig(sample_nex):
         ["Acquirer_comm", "Analysis_comm", "GUI_comm"]
     )
 
+def test_argument_config_precedence(setdir, ports):
+    store_size = 11_000_000
+    nex = Nexus("test")
+    nex.createNexus(
+        file="minimal_with_settings.yaml", control_port=ports[0], output_port=ports[1],
+        store_size=store_size
+    )
+    cfg = nex.config.settings
+    nex.destroyNexus()
+    assert cfg['control_port'] == ports[0]
+    assert cfg['output_port'] == ports[1]
+    assert cfg['store_size'] == 20_000_000
 
 # delete this comment later
 @pytest.mark.skip(reason="unfinished")

--- a/test/test_nexus.py
+++ b/test/test_nexus.py
@@ -7,7 +7,6 @@ import signal
 
 from improv.nexus import Nexus
 from improv.store import StoreInterface
-from subprocess import TimeoutExpired
 
 
 # from improv.actor import Actor
@@ -98,13 +97,20 @@ def test_createNexus(setdir, ports):
     nex.destroyNexus()
     assert True
 
+
 def test_config_logged(setdir, ports, caplog):
     nex = Nexus("test")
     nex.createNexus(
         file="minimal_with_settings.yaml", control_port=ports[0], output_port=ports[1]
     )
     nex.destroyNexus()
-    assert any(["not_relevant: for testing purposes" in record.msg for record in caplog.records])
+    assert any(
+        [
+            "not_relevant: for testing purposes" in record.msg
+            for record in caplog.records
+        ]
+    )
+
 
 def test_loadConfig(sample_nex):
     nex = sample_nex
@@ -113,19 +119,25 @@ def test_loadConfig(sample_nex):
         ["Acquirer_comm", "Analysis_comm", "GUI_comm"]
     )
 
+
 def test_argument_config_precedence(setdir, ports):
     nex = Nexus("test")
     nex.createNexus(
-        file="minimal_with_settings.yaml", control_port=ports[0], output_port=ports[1],
-        store_size=11_000_000, use_hdd=True, use_watcher=True
+        file="minimal_with_settings.yaml",
+        control_port=ports[0],
+        output_port=ports[1],
+        store_size=11_000_000,
+        use_hdd=True,
+        use_watcher=True,
     )
     cfg = nex.config.settings
     nex.destroyNexus()
-    assert cfg['control_port'] == ports[0]
-    assert cfg['output_port'] == ports[1]
-    assert cfg['store_size'] == 20_000_000
-    assert not cfg['use_hdd']
-    assert not cfg['use_watcher']
+    assert cfg["control_port"] == ports[0]
+    assert cfg["output_port"] == ports[1]
+    assert cfg["store_size"] == 20_000_000
+    assert not cfg["use_hdd"]
+    assert not cfg["use_watcher"]
+
 
 # delete this comment later
 @pytest.mark.skip(reason="unfinished")

--- a/test/test_nexus.py
+++ b/test/test_nexus.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 import subprocess
 import signal
+import yaml
 
 from improv.nexus import Nexus
 from improv.store import StoreInterface
@@ -111,7 +112,6 @@ def test_config_logged(setdir, ports, caplog):
         ]
     )
 
-
 def test_loadConfig(sample_nex):
     nex = sample_nex
     nex.loadConfig("good_config.yaml")
@@ -137,6 +137,18 @@ def test_argument_config_precedence(setdir, ports):
     assert cfg["store_size"] == 20_000_000
     assert not cfg["use_hdd"]
     assert not cfg["use_watcher"]
+
+def test_settings_override_random_ports(setdir, ports):
+    config_file = "minimal_with_settings.yaml"
+    nex = Nexus("test")
+    with open(config_file, "r") as ymlfile:
+        cfg = yaml.safe_load(ymlfile)["settings"]
+    control_port, output_port = nex.createNexus(
+        file=config_file, control_port=0, output_port=0
+    )
+    nex.destroyNexus()
+    assert control_port == cfg["control_port"]
+    assert output_port == cfg["output_port"]
 
 
 # delete this comment later

--- a/test/test_nexus.py
+++ b/test/test_nexus.py
@@ -112,6 +112,7 @@ def test_config_logged(setdir, ports, caplog):
         ]
     )
 
+
 def test_loadConfig(sample_nex):
     nex = sample_nex
     nex.loadConfig("good_config.yaml")
@@ -137,6 +138,7 @@ def test_argument_config_precedence(setdir, ports):
     assert cfg["store_size"] == 20_000_000
     assert not cfg["use_hdd"]
     assert not cfg["use_watcher"]
+
 
 def test_settings_override_random_ports(setdir, ports):
     config_file = "minimal_with_settings.yaml"

--- a/test/test_nexus.py
+++ b/test/test_nexus.py
@@ -114,17 +114,18 @@ def test_loadConfig(sample_nex):
     )
 
 def test_argument_config_precedence(setdir, ports):
-    store_size = 11_000_000
     nex = Nexus("test")
     nex.createNexus(
         file="minimal_with_settings.yaml", control_port=ports[0], output_port=ports[1],
-        store_size=store_size
+        store_size=11_000_000, use_hdd=True, use_watcher=True
     )
     cfg = nex.config.settings
     nex.destroyNexus()
     assert cfg['control_port'] == ports[0]
     assert cfg['output_port'] == ports[1]
     assert cfg['store_size'] == 20_000_000
+    assert not cfg['use_hdd']
+    assert not cfg['use_watcher']
 
 # delete this comment later
 @pytest.mark.skip(reason="unfinished")


### PR DESCRIPTION
Closes #159 

- `settings` was already recognized and checked for in YAML
- needed to put file reading and `settings` reading in `Config` constructor
- `nexus.loadConfig` now only creates the config; `nexus.initConfig` initializes (needed to do this because config should be read early in order to override defaults but can only be initialized later, once connections set up, store started, etc.)
- cleaned up some bad code style in `test_config.py`
- `test_sigint_exits_cleanly` was really brittle, so had to fix. ==TBD==
- **port settings given at the command line take precedence over those in the yaml file** (all other config options take precedence over defaults in the Nexus constructor)