### PR TITLE
adding CI files for publishing to PyPI and TestPyPI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pyproject.toml export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-pyproject.toml export-subst

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,9 +1,10 @@
 # based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 name: Publish Python 🐍 distribution 📦 to PyPI 
 
-on: push
-  tags: 
-    - 'v[0-9]+.[0-9]+.[0-9]+'
+on: 
+  push:
+    tags: 
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,5 +1,5 @@
 # based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
-name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distribution 📦 to PyPI 
 
 on: push
   tags: 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -3,7 +3,7 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 
 on: push
   tags: 
-  - "v[0-9]*"
+    - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -3,7 +3,7 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 
 on: push
   tags: 
-    - 'v[0-9]*'
+  - "v[0-9]*"
 
 jobs:
   build:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,96 @@
+# based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on: push
+  tags: 
+    - 'v[0-9]*'
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    # if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/improv
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -1,0 +1,54 @@
+
+# based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/improv
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -24,7 +24,6 @@ jobs:
     - name: Git Version
       run: |
         git --version
-        git describe
         git describe --tags
         git tag
     - name: Build a binary wheel and a source tarball

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-tags: true
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -26,6 +26,7 @@ jobs:
     - name: Git Version
       run: |
         git --version
+        git describe --tags
         git tag
     - name: Build a binary wheel and a source tarball
       run: python3 -m build

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -22,7 +22,11 @@ jobs:
         build
         --user
     - name: Git Version
-      run: git --version
+      run: >- 
+        git --version
+        git describe
+        git describe --tags
+        git tag
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -21,6 +21,8 @@ jobs:
         pip install
         build
         --user
+    - name: Git Version
+      run: git --version
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -24,7 +24,6 @@ jobs:
     - name: Git Version
       run: |
         git --version
-        git describe --tags
         git tag
     - name: Build a binary wheel and a source tarball
       run: python3 -m build

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -1,6 +1,6 @@
 
 # based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
-name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on: push
 

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -22,7 +22,7 @@ jobs:
         build
         --user
     - name: Git Version
-      run: >- 
+      run: |
         git --version
         git describe
         git describe --tags

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-pypi.yaml
+++ b/.github/workflows/test-pypi.yaml
@@ -23,11 +23,6 @@ jobs:
         pip install
         build
         --user
-    - name: Git Version
-      run: |
-        git --version
-        git describe --tags
-        git tag
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages

--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,4 @@ arrow
 .vscode/
 
 *.code-workspace
-
+improv/_version.py

--- a/demos/bubblewrap/README.md
+++ b/demos/bubblewrap/README.md
@@ -1,8 +1,8 @@
 # Running Bubblewrap demo
 ## Ubuntu users
-After installing improv, install additional dependencies (JAX on CPU by default) by being in the improv directory and do:
+After installing improv, install additional dependencies (JAX on CPU by default) navigating to `demos/bubblewrap` and doing
 
-- `pip install -e ".[bw_demo]"`
+- `pip install -r requirements.txt`
 
 To download the sample data from the paper, do:
 

--- a/demos/bubblewrap/requirements.txt
+++ b/demos/bubblewrap/requirements.txt
@@ -1,0 +1,5 @@
+pyqtgraph
+mat73
+jax[cpu]
+proSVD 
+bubblewrap@git+https://github.com/pearsonlab/Bubblewrap

--- a/improv/__init__.py
+++ b/improv/__init__.py
@@ -1,0 +1,1 @@
+from ._version import __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ exclude = '''
 
 [tool.versioningit.vcs]
 method = "git-archive"
-match = ["v*"]
+describe-subst = "$Format:%(describe:match=v*)$"
 
 [tool.versioningit.write]
 file = "improv/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ exclude = '''
 [tool.versioningit]
 
 [tool.versioningit.vcs]
+vcs = "git-archive"
 match = ["v*"]
 
 [tool.versioningit.write]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,7 @@ exclude = '''
 [tool.versioningit]
 
 [tool.versioningit.vcs]
-method = "git-archive"
-describe-subst = "$Format:%(describe:match=v*)$"
+match = ["v*"]
 
 [tool.versioningit.write]
 file = "improv/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "improv"
 version = "0.0.2"
 description = "Platform for adaptive neuroscience experiments"
-authors = [{name = "Anne Draelos", email = "amw73@duke.edu"}, 
+authors = [{name = "Anne Draelos", email = "adraelos@umich.edu"}, 
             {name = "John Pearson", email = "john.pearson@duke.edu"}]
 
 license = {file = "LICENSE"}
@@ -32,9 +32,6 @@ classifiers = ['Development Status :: 1 - Planning']
 tests = ["pytest", "async-timeout", "pytest-asyncio", "pytest-cov", "scikit-image",]
 docs = ["jupyter-book"]
 lint = ["black", "flake8", "Flake8-pyproject", "flake8-pytest-style"]
-bw_demo = ["pyqtgraph", "mat73", "jax[cpu]", "proSVD",  
-           "bubblewrap@git+https://github.com/pearsonlab/Bubblewrap",]
-caiman = []
 
 [project.scripts]
 improv = "improv.cli:default_invocation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "improv"
-version = "0.2"
 description = "Platform for adaptive neuroscience experiments"
 authors = [{name = "Anne Draelos", email = "adraelos@umich.edu"}, 
             {name = "John Pearson", email = "john.pearson@duke.edu"}]
@@ -27,6 +26,7 @@ dependencies = [
     "h5py",
 ]
 classifiers = ['Development Status :: 1 - Planning']
+dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = ["pytest", "async-timeout", "pytest-asyncio", "pytest-cov", "scikit-image",]
@@ -75,3 +75,11 @@ exclude = '''
   | build
 )/
 '''
+
+[tool.versioningit]
+
+[tool.versioningit.vcs]
+match = ["v*"]
+
+[tool.versioningit.write]
+file = "improv/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ exclude = '''
 [tool.versioningit]
 
 [tool.versioningit.vcs]
-vcs = "git-archive"
+method = "git-archive"
 match = ["v*"]
 
 [tool.versioningit.write]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,5 +81,21 @@ exclude = '''
 [tool.versioningit.vcs]
 match = ["v*"]
 
+[tool.versioningit.next-version]
+method = "smallest"
+
+[tool.versioningit.format]
+# Format used when there have been commits since the most recent tag:
+distance = "{next_version}.dev{distance}"
+# Example formatted version: 1.2.4.dev42+ge174a1f
+
+# Format used when there are uncommitted changes:
+dirty = "{base_version}+d{build_date:%Y%m%d}"
+# Example formatted version: 1.2.3+d20230922
+
+# Format used when there are both commits and uncommitted changes:
+distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
+# Example formatted version: 1.2.4.dev42+ge174a1f.d20230922
+
 [tool.versioningit.write]
 file = "improv/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "improv"
-version = "0.0.2"
+version = "0.2"
 description = "Platform for adaptive neuroscience experiments"
 authors = [{name = "Anne Draelos", email = "adraelos@umich.edu"}, 
             {name = "John Pearson", email = "john.pearson@duke.edu"}]


### PR DESCRIPTION
Will upload to `test.pypi.org` on any `push` to `main` and to `pypi.org` on any tag push of the form `v[0-9]*`.