### PR TITLE
pinning sphinx-autoapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = ['Development Status :: 1 - Planning']
 
 [project.optional-dependencies]
 tests = ["pytest", "async-timeout", "pytest-asyncio", "pytest-cov", "scikit-image",]
-docs = ["jupyter-book", "sphinx-autoapi"]
+docs = ["jupyter-book", "sphinx-autoapi==2.0.1"]
 lint = ["black", "flake8", "Flake8-pyproject", "flake8-pytest-style"]
 bw_demo = ["pyqtgraph", "mat73", "jax[cpu]", "proSVD",  
            "bubblewrap@git+https://github.com/pearsonlab/Bubblewrap",]


### PR DESCRIPTION
- jupyter-book wants sphinx 5.0.2, which is only compatible up to sphinx-autoapi 2.0.1