### PR TITLE
setting up coveralls properly for parallel builds

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -74,11 +74,11 @@ jobs:
           pip install flake8
           flake8 
 
-finish:
-  needs: test
-  runs-on: ubuntu-latest
-  steps:
-    - name: Close parallel build
-      uses: coverallsapp/github-action@v1
-      with:
-        parallel-finished: true
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v1
+        with:
+          parallel-finished: true

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Coveralls
         uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
 
 
   check-format:
@@ -72,3 +74,11 @@ jobs:
           pip install flake8
           flake8 
 
+finish:
+  needs: test
+  runs-on: ubuntu-latest
+  steps:
+    - name: Close parallel build
+      uses: coverallsapp/github-action@v1
+      with:
+        parallel-finished: true


### PR DESCRIPTION
Make sure Coveralls is correctly set up for multiple builds.

More info [here](https://docs.coveralls.io/parallel-builds). 