### PR TITLE
small docs and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI](https://img.shields.io/pypi/v/improv?style=flat-square?style=flat-square)](https://pypi.org/project/improv)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/improv?style=flat-square)](https://pypi.org/project/improv)
 [![docs](https://github.com/project-improv/improv/actions/workflows/docs.yaml/badge.svg?style=flat-square)](https://project-improv.github.io/)
-[![tests](https://github.com/project-improv/improv/actions/workflows/CI.yaml/badge.svg?style=flat-square)](https://project-improv.github.io/)
+[![tests](https://github.com/project-improv/improv/actions/workflows/CI.yaml/badge.svg?style=flat-square)](https://github.com/project-improv/improv/actions/workflows/CI.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/project-improv/improv/badge.svg?branch=main)](https://coveralls.io/github/project-improv/improv?branch=main)
 [![PyPI - License](https://img.shields.io/pypi/l/improv?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A flexible software platform for real-time and adaptive neuroscience experiments
 
 _improv_ is a streaming software platform designed to enable adaptive experiments. By analyzing data, such as 2-photon calcium images, as it comes in, we can obtain information about the current brain state in real time and use it to adaptively modify an experiment as data collection is ongoing. 
 
-![](https://dibs-web01.vm.duke.edu/pearson/assets/improv/improvGif.gif)
+<!-- ![](https://dibs-web01.vm.duke.edu/pearson/assets/improv/improvGif.gif) -->
+![](https://dibs-files.cloud.duke.edu/sites/default/files/improvGif.gif)
 
 This video shows raw 2-photon calcium imaging data in zebrafish, with cells detected in real time by [CaImAn](https://github.com/flatironinstitute/CaImAn), and directional tuning curves (shown as colored neurons) and functional connectivity (lines) estimated online, during a live experiment. Here only a few minutes of data have been acquired, and neurons are colored by their strongest response to visual simuli shown so far.
 We also provide up-to-the-moment estimates of the functional connectivity by fitting linear-nonlinear-Poisson models online, as each new piece of data is acquired. Simple visualizations offer real-time insights, allowing for adaptive experiments that change in response to the current state of the brain.
@@ -19,14 +20,15 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 
 ### How improv works
 
-<img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%>
-<img src="https://bme.umich.edu/wp-content/uploads/2023/10/Screenshot-2023-10-03-at-10.51.46-AM-1920x1485.png" width=85%>
+<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
+<img src="https://dibs-files.cloud.duke.edu/sites/default/files/improv_design.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />
   <br />
   
-<img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/actor_model.png" width=60%>
+<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/actor_model.png" width=60%> -->
+<img src="https://dibs-files.cloud.duke.edu/sites/default/files/actor_model.png" width=60%>
 
 _improv_'s design is based on a streamlined version of the actor model for concurrent computation. Each component of the system (experimental pipeline) is considered an 'actor' and has a unique role. They interact via message passing, without the need for a central broker. Actors are implemented as user-defined classes that inherit from _improv_'s `Actor` class, which supplies all queues for message passing and orchestrates process execution and error handling. Messages between actors are composed of keys that correspond to items in a shared, in-memory data store. This both minimizes communication overhead and data copying between processes. 
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 
 ### How improv works
 
-<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
-<img src="https://duke.box.com/shared/static/b6jkfkmbozla7x0cbjd0ezrdpmb3fqzo.png" width=85%>
+<img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A flexible software platform for real-time and adaptive neuroscience experiments
 
 _improv_ is a streaming software platform designed to enable adaptive experiments. By analyzing data, such as 2-photon calcium images, as it comes in, we can obtain information about the current brain state in real time and use it to adaptively modify an experiment as data collection is ongoing. 
 
-<!-- ![](https://dibs-web01.vm.duke.edu/pearson/assets/improv/improvGif.gif) -->
 ![](https://dibs-files.cloud.duke.edu/sites/default/files/improvGif.gif)
 
 This video shows raw 2-photon calcium imaging data in zebrafish, with cells detected in real time by [CaImAn](https://github.com/flatironinstitute/CaImAn), and directional tuning curves (shown as colored neurons) and functional connectivity (lines) estimated online, during a live experiment. Here only a few minutes of data have been acquired, and neurons are colored by their strongest response to visual simuli shown so far.
@@ -20,14 +19,12 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 
 ### How improv works
 
-<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
 <img src="https://dibs-files.cloud.duke.edu/sites/default/files/improv_design.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />
   <br />
   
-<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/actor_model.png" width=60%> -->
 <img src="https://dibs-files.cloud.duke.edu/sites/default/files/actor_model.png" width=60%>
 
 _improv_'s design is based on a streamlined version of the actor model for concurrent computation. Each component of the system (experimental pipeline) is considered an 'actor' and has a unique role. They interact via message passing, without the need for a central broker. Actors are implemented as user-defined classes that inherit from _improv_'s `Actor` class, which supplies all queues for message passing and orchestrates process execution and error handling. Messages between actors are composed of keys that correspond to items in a shared, in-memory data store. This both minimizes communication overhead and data copying between processes. 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 ### How improv works
 
 <!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
-<img src="https://www.neuro.duke.edu/sites/default/files/2021-03/neurobiology-logo-white.svg" width=85%>
+<img src="https://bme.umich.edu/wp-content/uploads/2023/10/Screenshot-2023-10-03-at-10.51.46-AM-1920x1485.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 ### How improv works
 
 <!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
-<img src="https://obsproject.com/assets/images/features-new/scenes.png" width=85%>
+<img src="https://dibs-web01.vm.duke.edu/pearson/assets/images/website/john.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 
 ### How improv works
 
-<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
+<img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%>
 <img src="https://bme.umich.edu/wp-content/uploads/2023/10/Screenshot-2023-10-03-at-10.51.46-AM-1920x1485.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 ### How improv works
 
 <!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
-<img src="https://dibs-web01.vm.duke.edu/pearson/assets/images/website/john.png" width=85%>
+<img src="https://www.neuro.duke.edu/sites/default/files/2021-03/neurobiology-logo-white.svg" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 
 ### How improv works
 
-<img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%>
+<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
+<img src="https://duke.box.com/shared/static/b6jkfkmbozla7x0cbjd0ezrdpmb3fqzo.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ We also provide up-to-the-moment estimates of the functional connectivity by fit
 
 ### How improv works
 
-<img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%>
+<!-- <img src="https://dibs-web01.vm.duke.edu/pearson/assets/improv/improv_design.png" width=85%> -->
+<img src="https://obsproject.com/assets/images/features-new/scenes.png" width=85%>
 
 improv allows users to flexibly specify and manage adaptive experiments to integrate data collection, preprocessing, visualization, and user-defined analytics. All kinds of behavioral, neural, or modeling data can be incorporated, and input and output data streams are managed independently and asynchronously. With this design, streaming analyses and real-time interventions can be easily integrated into various experimental setups. improv manages the backend engineering of data flow and task execution for all steps in an experimental pipeline in real time, without requiring user oversight. Users need only define their particular processing pipeline with simple text files and are free to define their own streaming analyses via Python classes, allowing for rapid prototyping of adaptive experiments.  
   <br />

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,20 +72,3 @@ Then simply run
 jupyter-book build docs
 ```
 and open `docs/_build/html/index.html` in your browser.
-
-## Getting around certificate issues
-
-On some systems, building (or installing from `pip`) can run into [this error](https://stackoverflow.com/questions/25981703/pip-install-fails-with-connection-error-ssl-certificate-verify-failed-certi) related to SSL certificates. For `pip`, the solution is given in the linked StackOverflow question (add `--trusted-host` to the command line), but for `build`, we run into the issue that the `trusted-host` flag will not be passed through to `pip`, and `pip` will build inside an isolated venv, meaning it won't read a file-based configuration option like the one given in the answer, either. 
-
-The (inelegant) solution that will work is to set the `pip.conf` file with
-```
-[global]
-trusted-host = pypi.python.org
-               pypi.org
-               files.pythonhosted.org
-```
-and then run
-```
-python -m build --no-isolation
-```
-which will allow `pip` to correctly read the configuration.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,11 +7,11 @@ The simplest way to install _improv_ is with pip:
 pip install improv
 ```
 ````{warning}
-Due to [this pyzmq issue](https://github.com/zeromq/libzmq/issues/3313), if you're running on Ubuntu, you need to specify
+Due to [this pyzmq issue](https://github.com/zeromq/libzmq/issues/3313), if you're running on Ubuntu, you _may_ need to specify
 ```
 pip install improv --no-binary pyzmq
 ```
-to build `pyzmq` from source.
+to build `pyzmq` from source if you're running into ZMQ errors.
 ````
 
 ## Optional dependencies

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,13 +48,10 @@ Currently, we build using [Setuptools](https://setuptools.pypa.io/en/latest/inde
 
 For now, the package can be built by running
 ```
-python -m build
-```
-from within the project directory. After that
-```
 pip install --editable .
 ```
-will install the package in editable mode, which means that changes in the project directory will affect the code that is run (i.e., the installation will not copy over the code to `site-packages` but simply link the project directory). 
+from within the project directory. 
+this will install the package in editable mode, which means that changes in the project directory will affect the code that is run (i.e., the installation will not copy over the code to `site-packages` but simply link the project directory). 
 
 When uninstalling, be sure to do so _from outside the project directory_, since otherwise, `pip` only appears to find the command line script, not the full package.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ classifiers = ['Development Status :: 3 - Alpha',
                'Programming Language :: Python :: 3.8',
                'Programming Language :: Python :: 3.9',
                'Programming Language :: Python :: 3.10',
-               'Programming Language :: Python :: 3.11',
-               'Programming Language :: Python :: 3.12',
                'Programming Language :: Python :: Implementation :: CPython'
                ]
 dynamic = ["version"]


### PR DESCRIPTION
Some small fixes, including:
- tests passing badge links to GitHub Actions page
- remove claim of Python 3.11, 3.12 support
- replace links on README with working versions
- some cleanup in installation docs