### PR TITLE
better error message for redis port already in use

### DIFF
--- a/docs/demos.ipynb
+++ b/docs/demos.ipynb
@@ -25,7 +25,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[34mactors\u001b[m\u001b[m\n",
+      "\u001B[34mactors\u001B[m\u001B[m\n",
       "minimal.yaml\n",
       "minimal_spawn.yaml\n",
       "\n",
@@ -91,6 +91,27 @@
     "<br>\n",
     "<br>\n",
     " "
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "**Note:** If you attempt to run the minimal demo and receive the following error: \n",
+    "```bash\n",
+    "Unable to read server start time from global.log.\n",
+    "This may be because the server could not be started or did not log its activity.\n",
+    "```\n",
+    "\n",
+    "Try running the following to fix the issue:\n",
+    "```bash\n",
+    "sudo systemctl stop redis-server\n",
+    "```\n",
+    "\n",
+    "It may be the case (especially if you just installed redis) that redis is already up and running on the default port (6379), and therefore improv is unable to connect on that port. You can also check the status of redis by running: \n",
+    "```bash\n",
+    "sudo systemctl status redis-server\n",
+    "``` "
    ]
   },
   {

--- a/improv/nexus.py
+++ b/improv/nexus.py
@@ -716,7 +716,12 @@ class Nexus:
                 self.p_StoreInterface = self.start_redis(size)
                 time.sleep(3)
                 if self.p_StoreInterface.poll():
-                    logger.error("Could not start Redis on specified port number.")
+                    logger.error(
+                        "Could not start Redis on specified port number. The port {} may already be in use.\n"
+                        "Try running `sudo systemctl stop redis' to fix the issue".format(
+                            self.store_port
+                        )
+                    )
                     raise Exception("Could not start Redis on specified port.")
             else:
                 logger.info("Redis port not specified. Searching for open port.")

--- a/improv/nexus.py
+++ b/improv/nexus.py
@@ -717,8 +717,9 @@ class Nexus:
                 time.sleep(3)
                 if self.p_StoreInterface.poll():
                     logger.error(
-                        "Could not start Redis on specified port number. The port {} may already be in use.\n"
-                        "Try running `sudo systemctl stop redis' to fix the issue".format(
+                        "Could not start Redis on specified port number. "
+                        "The port {} may already be in use.\n"
+                        "Run `sudo systemctl stop redis' to help fix the issue.".format(
                             self.store_port
                         )
                     )


### PR DESCRIPTION
closes #198 